### PR TITLE
Fix add new block with save and continue editing

### DIFF
--- a/glitter/blockadmin/blocks.py
+++ b/glitter/blockadmin/blocks.py
@@ -351,8 +351,12 @@ class BlockAdmin(ModelAdmin):
         if '_continue' in request.POST:
             msg = _('The block was added successfully. You may edit it again below.')
             self.message_user(request, msg, messages.SUCCESS)
+
+            # We redirect to the save and continue page, which updates the
+            # parent window in javascript and redirects back to the edit page
+            # in javascript.
             post_url_continue = reverse(
-                'block_admin:%s_%s_change' % (opts.app_label, opts.model_name),
+                'block_admin:%s_%s_continue' % (opts.app_label, opts.model_name),
                 args=(quote(pk_value),),
                 current_app=self.admin_site.name
             )

--- a/glitter/tests/test_admin.py
+++ b/glitter/tests/test_admin.py
@@ -352,8 +352,9 @@ class TestPageBlockAddView(BaseViewsCase):
         response = self.editor_client.post(self.page_block_add_view_url, {
             'content': '<p>Test</p>',
             '_continue': '',
-        })
-        self.assertEqual(response.status_code, 302)
+        }, follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'blockadmin/continue.html')
 
     def test_page_version(self):
         """ Check page version. """


### PR DESCRIPTION
When adding a new block and choosing the "Save and continue" option, we need to redirect to the custom continue view which reloads the column in the background.

Fixes #100