### PR TITLE
Reset add block dropdown after adding one

### DIFF
--- a/glitter/static/glitter/js/glitter_editor.js
+++ b/glitter/static/glitter/js/glitter_editor.js
@@ -189,6 +189,7 @@ GlitterEditor.jQuery = jQuery.noConflict(true);
 
         $(document).on("change", ".glitter-add-block-select", function() {
             var iframe_url = $(this).val();
+            this.selectedIndex = undefined;
             iframe_popup(iframe_url);
         });
 


### PR DESCRIPTION
It's possible to close a popup without the HTML of a column changing - so the dropdown needs resetting incase a user wants to add the same block again

Fixes #79