### PR TITLE
Stop reminders/publisher inlines appearing everywhere

### DIFF
--- a/glitter/pages/admin.py
+++ b/glitter/pages/admin.py
@@ -88,12 +88,12 @@ class PageAdmin(GlitterAdminMixin, DjangoMpttAdmin, MPTTModelAdmin):
         if apps.is_installed('glitter.publisher'):
             from glitter.publisher.admin import ActionInline
             if ActionInline not in self.inlines:
-                self.inlines.append(ActionInline)
+                self.inlines = self.inlines + [ActionInline]
 
         if apps.is_installed('glitter.reminders'):
             from glitter.reminders.admin import ReminderInline
             if ReminderInline not in self.inlines:
-                self.inlines.append(ReminderInline)
+                self.inlines = self.inlines + [ReminderInline]
 
         return super(PageAdmin, self).get_inline_instances(request, obj)
 


### PR DESCRIPTION
As this is the Django admin, self.inlines is a list which is defined on the class - so it's a mutable object.

Instead of appending to it, we define a new list here.

Ideally I'd like something better at some point - however for now this fixes the bug.