### PR TITLE
Fix performance for AssetForeignKey

### DIFF
--- a/glitter/assets/fields.py
+++ b/glitter/assets/fields.py
@@ -20,7 +20,7 @@ class GroupedModelChoiceField(ModelChoiceField):
             self.group_label = group_label
 
         # Need correct ordering, and category titles
-        self.queryset = self.queryset.select_related().order_by('category', 'title')
+        self.queryset = self.queryset.select_related('category').order_by('category', 'title')
 
     def _get_choices(self):
         """


### PR DESCRIPTION
#97 made category optional, and with null ForeignKeys we have to force a select_related on them.

Backport of 79acfd42a4c9eccc1d365412fca9186b568e4d6d for stable branch.