### PR TITLE
Add a position field to banner/carousel inlines

### DIFF
--- a/glitter/blocks/banner/migrations/0005_inline_position.py
+++ b/glitter/blocks/banner/migrations/0005_inline_position.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('glitter_banner', '0004_delete_empty_blocks'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='bannerinline',
+            options={'ordering': ('position', 'id'), 'verbose_name': 'banner'},
+        ),
+        migrations.AddField(
+            model_name='bannerinline',
+            name='position',
+            field=models.PositiveIntegerField(db_index=True, default=0),
+        ),
+    ]

--- a/glitter/blocks/banner/models.py
+++ b/glitter/blocks/banner/models.py
@@ -30,10 +30,11 @@ class BannerBlock(BaseBlock):
 class BannerInline(models.Model):
     banner_block = models.ForeignKey(BannerBlock)
     banner = models.ForeignKey(Banner, on_delete=models.PROTECT)
+    position = models.PositiveIntegerField(default=0, db_index=True)
 
     class Meta:
         verbose_name = 'banner'
-        ordering = ('id',)
+        ordering = ('position', 'id')
 
     def __str__(self):
         return '%s' % (self.banner,) or 'Banner'

--- a/glitter/blocks/carousel/migrations/0006_inline_position.py
+++ b/glitter/blocks/carousel/migrations/0006_inline_position.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('glitter_carousel', '0005_carousel_required'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='carouselimage',
+            options={'ordering': ('position', 'id')},
+        ),
+        migrations.AlterModelOptions(
+            name='imageonlycarouselimage',
+            options={'ordering': ('position', 'id')},
+        ),
+        migrations.AddField(
+            model_name='carouselimage',
+            name='position',
+            field=models.PositiveIntegerField(db_index=True, default=0),
+        ),
+        migrations.AddField(
+            model_name='imageonlycarouselimage',
+            name='position',
+            field=models.PositiveIntegerField(db_index=True, default=0),
+        ),
+    ]

--- a/glitter/blocks/carousel/models.py
+++ b/glitter/blocks/carousel/models.py
@@ -26,9 +26,10 @@ class BaseCarouselImage(models.Model):
     subtitle = models.TextField(blank=True)
     image = AssetForeignKey('glitter_assets.Image', on_delete=models.PROTECT)
     link = LinkField()
+    position = models.PositiveIntegerField(default=0, db_index=True)
 
     class Meta:
-        ordering = ('id',)
+        ordering = ('position', 'id')
         abstract = True
 
     def __str__(self):
@@ -53,9 +54,10 @@ class ImageOnlyCarousel(BaseCarousel):
 class BaseImageOnlyCarouselImage(models.Model):
     carousel = models.ForeignKey(ImageOnlyCarousel, related_name='carousel_images')
     image = AssetForeignKey('glitter_assets.Image', on_delete=models.PROTECT)
+    position = models.PositiveIntegerField(default=0, db_index=True)
 
     class Meta:
-        ordering = ('id',)
+        ordering = ('position', 'id')
         abstract = True
 
     def __str__(self):


### PR DESCRIPTION
We can't guarantee the ordering of inlines when pages get copied for new versions.

This is a bit of a workaround - but it does the job of stopping inlines moving around on save.