### PR TITLE
Loosen django-mptt requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 install_requires = [
     'Django>=1.8,<1.10',
-    'django-mptt>=0.7,<0.9',
+    'django-mptt>=0.7',
     'django-mptt-admin>=0.3',
     'sorl-thumbnail>=12.2',
     'django-taggit>=0.21.3',


### PR DESCRIPTION
Not needed - currently causing problems with updated project requirements

Backport to the 0.2 stable branch - will do a release shortly.