### PR TITLE
Stable str fix version 0.1.13

### DIFF
--- a/glitter/blocks/text_image/models.py
+++ b/glitter/blocks/text_image/models.py
@@ -16,6 +16,10 @@ class BaseTextImageBlock(BaseBlock):
     class Meta:
         abstract = True
 
+    def __str__(self):
+        if self.content_block:
+            return str(self.content_block)
+
 
 class TextImageBlock(BaseTextImageBlock):
     class Meta:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ install_requires = [
 
 setup(
     name='django-glitter',
-    version='0.1.12',
+    version='0.1.13',
     description='Glitter for Django',
     long_description=open('README.rst').read(),
     url='https://github.com/blancltd/django-glitter',


### PR DESCRIPTION
For card: https://favro.com/organization/b03d6d6d9b11b61167ac4246/418c53a770389640d415a230?card=Dev-6035

Added str method to the BaseImageTextBlock, also incremented the version number in `setup.py` as there is no `.bumpversion.cfg` on this branch.

Adding these changes to version 0.1 as the Lichfield site is running the older version.
(`https://github.com/developersociety/cofelichfield/blob/master/requirements/base.txt#L22`)

